### PR TITLE
Master - fixed packagesetup - install stats

### DIFF
--- a/var/packagesetup/ITSMServiceLevelManagement.pm
+++ b/var/packagesetup/ITSMServiceLevelManagement.pm
@@ -108,6 +108,7 @@ sub CodeInstall {
     # install stats
     $Kernel::OM->Get('Kernel::System::Stats')->StatsInstall(
         FilePrefix => $Self->{FilePrefix},
+        UserID => 1,
     );
 
     return 1;
@@ -127,6 +128,7 @@ sub CodeReinstall {
     # install stats
     $Kernel::OM->Get('Kernel::System::Stats')->StatsInstall(
         FilePrefix => $Self->{FilePrefix},
+        UserID => 1,
     );
 
     return 1;
@@ -146,6 +148,7 @@ sub CodeUpgrade {
     # install stats
     $Kernel::OM->Get('Kernel::System::Stats')->StatsInstall(
         FilePrefix => $Self->{FilePrefix},
+        UserID => 1,
     );
 
     return 1;
@@ -165,6 +168,7 @@ sub CodeUninstall {
     # uninstall stats
     $Kernel::OM->Get('Kernel::System::Stats')->StatsUninstall(
         FilePrefix => $Self->{FilePrefix},
+        UserID => 1,
     );
 
     return 1;


### PR DESCRIPTION
Hi @UdoBretz 

I tested it and noticed that there is a problem with StatsInstall function in packagesetup modules for ITSM.
I will check all ITSM package during update for CodeUpgrade function.

Now, it is possible to install stats from this package, but there are some syslog error. I think that we should update these stats and adapt to new statistics from the framework.

If you want we will be able to do this when we have time for such task.

Regards
Zoran