### PR TITLE
Removed punctuation from title

### DIFF
--- a/var/stats/ITSMStats-001-Ticket.xml
+++ b/var/stats/ITSMStats-001-Ticket.xml
@@ -23,7 +23,7 @@ Restrictions:
 <StatType>dynamic</StatType>
 <SumCol>1</SumCol>
 <SumRow>1</SumRow>
-<Title>Total number of all tickets ever created per Ticket-Type and Priority.</Title>
+<Title>Total number of all tickets ever created per Ticket-Type and Priority</Title>
 <UseAsValueSeries Element="PriorityIDs" Fixed="1">
 </UseAsValueSeries>
 <UseAsXvalue Element="TypeIDs" Fixed="1">

--- a/var/stats/ITSMStats-002-Ticket.xml
+++ b/var/stats/ITSMStats-002-Ticket.xml
@@ -23,7 +23,7 @@ Restrictions:
 <StatType>dynamic</StatType>
 <SumCol>1</SumCol>
 <SumRow>1</SumRow>
-<Title>Total number of all tickets ever created per Ticket-Type and State.</Title>
+<Title>Total number of all tickets ever created per Ticket-Type and State</Title>
 <UseAsValueSeries Element="StateIDs" Fixed="1">
 </UseAsValueSeries>
 <UseAsXvalue Element="TypeIDs" Fixed="1">

--- a/var/stats/ITSMStats-003-Ticket.xml
+++ b/var/stats/ITSMStats-003-Ticket.xml
@@ -23,7 +23,7 @@ Restrictions:
 <StatType>dynamic</StatType>
 <SumCol>1</SumCol>
 <SumRow>1</SumRow>
-<Title>Total number of all tickets ever created per Ticket-Type and Queue.</Title>
+<Title>Total number of all tickets ever created per Ticket-Type and Queue</Title>
 <UseAsValueSeries Element="QueueIDs" Fixed="1">
 </UseAsValueSeries>
 <UseAsXvalue Element="TypeIDs" Fixed="1">

--- a/var/stats/ITSMStats-004-Ticket.xml
+++ b/var/stats/ITSMStats-004-Ticket.xml
@@ -23,7 +23,7 @@ Restrictions:
 <StatType>dynamic</StatType>
 <SumCol>1</SumCol>
 <SumRow>1</SumRow>
-<Title>Total number of all tickets ever created per Ticket-Type and Service.</Title>
+<Title>Total number of all tickets ever created per Ticket-Type and Service</Title>
 <UseAsValueSeries Element="ServiceIDs" Fixed="1">
 </UseAsValueSeries>
 <UseAsXvalue Element="TypeIDs" Fixed="1">

--- a/var/stats/ITSMStats-005-Ticket.xml
+++ b/var/stats/ITSMStats-005-Ticket.xml
@@ -22,7 +22,7 @@ Restrictions:
 <StatType>dynamic</StatType>
 <SumCol>1</SumCol>
 <SumRow>1</SumRow>
-<Title>Monthly overview of all tickets created in the last month per Ticket-Type.</Title>
+<Title>Monthly overview of all tickets created in the last month per Ticket-Type</Title>
 <UseAsValueSeries Element="TypeIDs" Fixed="1">
 </UseAsValueSeries>
 <UseAsXvalue Element="CreateTime" TimeRelativeCount="1" TimeRelativeUnit="Month" TimeScaleCount="1">

--- a/var/stats/ITSMStats-006-Ticket.xml
+++ b/var/stats/ITSMStats-006-Ticket.xml
@@ -22,7 +22,7 @@ Restrictions:
 <StatType>dynamic</StatType>
 <SumCol>1</SumCol>
 <SumRow>1</SumRow>
-<Title>Monthly overview of all tickets created in the last month per Priority.</Title>
+<Title>Monthly overview of all tickets created in the last month per Priority</Title>
 <UseAsValueSeries Element="PriorityIDs" Fixed="1">
 </UseAsValueSeries>
 <UseAsXvalue Element="CreateTime" TimeRelativeCount="1" TimeRelativeUnit="Month" TimeScaleCount="1">

--- a/var/stats/ITSMStats-007-Ticket.xml
+++ b/var/stats/ITSMStats-007-Ticket.xml
@@ -22,7 +22,7 @@ Restrictions:
 <StatType>dynamic</StatType>
 <SumCol>1</SumCol>
 <SumRow>1</SumRow>
-<Title>Monthly overview of all tickets created in the last month per State.</Title>
+<Title>Monthly overview of all tickets created in the last month per State</Title>
 <UseAsValueSeries Element="StateIDs" Fixed="1">
 </UseAsValueSeries>
 <UseAsXvalue Element="CreateTime" TimeRelativeCount="1" TimeRelativeUnit="Month" TimeScaleCount="1">

--- a/var/stats/ITSMStats-008-Ticket.xml
+++ b/var/stats/ITSMStats-008-Ticket.xml
@@ -22,7 +22,7 @@ Restrictions:
 <StatType>dynamic</StatType>
 <SumCol>1</SumCol>
 <SumRow>1</SumRow>
-<Title>Monthly overview of all tickets created in the last month per Queue.</Title>
+<Title>Monthly overview of all tickets created in the last month per Queue</Title>
 <UseAsValueSeries Element="QueueIDs" Fixed="1">
 </UseAsValueSeries>
 <UseAsXvalue Element="CreateTime" TimeRelativeCount="1" TimeRelativeUnit="Month" TimeScaleCount="1">

--- a/var/stats/ITSMStats-009-Ticket.xml
+++ b/var/stats/ITSMStats-009-Ticket.xml
@@ -22,7 +22,7 @@ Restrictions:
 <StatType>dynamic</StatType>
 <SumCol>1</SumCol>
 <SumRow>1</SumRow>
-<Title>Monthly overview of all tickets created in the last month per Service.</Title>
+<Title>Monthly overview of all tickets created in the last month per Service</Title>
 <UseAsValueSeries Element="ServiceIDs" Fixed="1">
 </UseAsValueSeries>
 <UseAsXvalue Element="CreateTime" TimeRelativeCount="1" TimeRelativeUnit="Month" TimeScaleCount="1">

--- a/var/stats/ITSMStats-010-Ticket.xml
+++ b/var/stats/ITSMStats-010-Ticket.xml
@@ -22,7 +22,7 @@ Restrictions:
 <StatType>dynamic</StatType>
 <SumCol>1</SumCol>
 <SumRow>1</SumRow>
-<Title>Number of tickets created in a specific time period per Ticket-Type and Priority.</Title>
+<Title>Number of tickets created in a specific time period per Ticket-Type and Priority</Title>
 <UseAsRestriction Element="CreateTime" TimeRelativeCount="1" TimeRelativeUnit="Month" TimeScaleCount="1">
 <SelectedValues>Day</SelectedValues>
 </UseAsRestriction>

--- a/var/stats/ITSMStats-011-Ticket.xml
+++ b/var/stats/ITSMStats-011-Ticket.xml
@@ -22,7 +22,7 @@ Restrictions:
 <StatType>dynamic</StatType>
 <SumCol>1</SumCol>
 <SumRow>1</SumRow>
-<Title>Number of tickets created in a specific time period per Ticket-Type and State.</Title>
+<Title>Number of tickets created in a specific time period per Ticket-Type and State</Title>
 <UseAsRestriction Element="CreateTime" TimeRelativeCount="1" TimeRelativeUnit="Month" TimeScaleCount="1">
 <SelectedValues>Day</SelectedValues>
 </UseAsRestriction>

--- a/var/stats/ITSMStats-012-Ticket.xml
+++ b/var/stats/ITSMStats-012-Ticket.xml
@@ -22,7 +22,7 @@ Restrictions:
 <StatType>dynamic</StatType>
 <SumCol>1</SumCol>
 <SumRow>1</SumRow>
-<Title>Number of tickets created in a specific time period per Ticket-Type and Queue.</Title>
+<Title>Number of tickets created in a specific time period per Ticket-Type and Queue</Title>
 <UseAsRestriction Element="CreateTime" TimeRelativeCount="1" TimeRelativeUnit="Month" TimeScaleCount="1">
 <SelectedValues>Day</SelectedValues>
 </UseAsRestriction>

--- a/var/stats/ITSMStats-013-Ticket.xml
+++ b/var/stats/ITSMStats-013-Ticket.xml
@@ -22,7 +22,7 @@ Restrictions:
 <StatType>dynamic</StatType>
 <SumCol>1</SumCol>
 <SumRow>1</SumRow>
-<Title>Number of tickets created in a specific time period per Ticket-Type and Service.</Title>
+<Title>Number of tickets created in a specific time period per Ticket-Type and Service</Title>
 <UseAsRestriction Element="CreateTime" TimeRelativeCount="1" TimeRelativeUnit="Month" TimeScaleCount="1">
 <SelectedValues>Day</SelectedValues>
 </UseAsRestriction>

--- a/var/stats/ITSMStats-014-Ticket.xml
+++ b/var/stats/ITSMStats-014-Ticket.xml
@@ -22,7 +22,7 @@ Restrictions:
 <StatType>dynamic</StatType>
 <SumCol>1</SumCol>
 <SumRow>1</SumRow>
-<Title>Number of currently open tickets per Ticket-Type and Priority.</Title>
+<Title>Number of currently open tickets per Ticket-Type and Priority</Title>
 <UseAsRestriction Element="StateTypeIDs" Fixed="1">
 <SelectedValues>2</SelectedValues>
 </UseAsRestriction>

--- a/var/stats/ITSMStats-015-Ticket.xml
+++ b/var/stats/ITSMStats-015-Ticket.xml
@@ -22,7 +22,7 @@ Restrictions:
 <StatType>dynamic</StatType>
 <SumCol>1</SumCol>
 <SumRow>1</SumRow>
-<Title>Number of currently open tickets per Ticket-Type and Queue.</Title>
+<Title>Number of currently open tickets per Ticket-Type and Queue</Title>
 <UseAsRestriction Element="StateTypeIDs" Fixed="1">
 <SelectedValues>2</SelectedValues>
 </UseAsRestriction>

--- a/var/stats/ITSMStats-016-Ticket.xml
+++ b/var/stats/ITSMStats-016-Ticket.xml
@@ -22,7 +22,7 @@ Restrictions:
 <StatType>dynamic</StatType>
 <SumCol>1</SumCol>
 <SumRow>1</SumRow>
-<Title>Number of currently open tickets per Ticket-Type and Service.</Title>
+<Title>Number of currently open tickets per Ticket-Type and Service</Title>
 <UseAsRestriction Element="StateTypeIDs" Fixed="1">
 <SelectedValues>2</SelectedValues>
 </UseAsRestriction>

--- a/var/stats/ITSMStats-100-ITSMConfigItem.xml
+++ b/var/stats/ITSMStats-100-ITSMConfigItem.xml
@@ -22,7 +22,7 @@ Restrictions:
 <StatType>dynamic</StatType>
 <SumCol>1</SumCol>
 <SumRow>1</SumRow>
-<Title>Total number of all config items ever created per Class and State.</Title>
+<Title>Total number of all config items ever created per Class and State</Title>
 <UseAsValueSeries Element="StateIDs" Fixed="1">
 </UseAsValueSeries>
 <UseAsXvalue Element="ClassIDs" Fixed="1">

--- a/var/stats/ITSMStats-101-ITSMConfigItem.xml
+++ b/var/stats/ITSMStats-101-ITSMConfigItem.xml
@@ -22,7 +22,7 @@ Restrictions:
 <StatType>dynamic</StatType>
 <SumCol>1</SumCol>
 <SumRow>1</SumRow>
-<Title>Monthly overview of all config items created in the last month per Class.</Title>
+<Title>Monthly overview of all config items created in the last month per Class</Title>
 <UseAsValueSeries Element="ClassIDs" Fixed="1">
 </UseAsValueSeries>
 <UseAsXvalue Element="CreateTime" TimeRelativeCount="1" TimeRelativeUnit="Month" TimeScaleCount="1">

--- a/var/stats/ITSMStats-102-ITSMConfigItem.xml
+++ b/var/stats/ITSMStats-102-ITSMConfigItem.xml
@@ -22,7 +22,7 @@ Restrictions:
 <StatType>dynamic</StatType>
 <SumCol>1</SumCol>
 <SumRow>1</SumRow>
-<Title>Monthly overview of all config items created in the last month per State.</Title>
+<Title>Monthly overview of all config items created in the last month per State</Title>
 <UseAsValueSeries Element="StateIDs" Fixed="1">
 </UseAsValueSeries>
 <UseAsXvalue Element="CreateTime" TimeRelativeCount="1" TimeRelativeUnit="Month" TimeScaleCount="1">

--- a/var/stats/ITSMStats-103-ITSMConfigItem.xml
+++ b/var/stats/ITSMStats-103-ITSMConfigItem.xml
@@ -22,7 +22,7 @@ Restrictions:
 <StatType>dynamic</StatType>
 <SumCol>1</SumCol>
 <SumRow>1</SumRow>
-<Title>Number of config items created in a specific time period per Class and State.</Title>
+<Title>Number of config items created in a specific time period per Class and State</Title>
 <UseAsRestriction Element="CreateTime" TimeRelativeCount="1" TimeRelativeUnit="Month" TimeScaleCount="1">
 <SelectedValues>Day</SelectedValues>
 </UseAsRestriction>

--- a/var/stats/ITSMStats-200-ITSMTicketFirstLevelSolutionRate.xml
+++ b/var/stats/ITSMStats-200-ITSMTicketFirstLevelSolutionRate.xml
@@ -23,7 +23,7 @@ Restrictions:
 <StatType>dynamic</StatType>
 <SumCol>1</SumCol>
 <SumRow>1</SumRow>
-<Title>First level solution rate for all tickets ever created per Ticket-Type and Priority.</Title>
+<Title>First level solution rate for all tickets ever created per Ticket-Type and Priority</Title>
 <UseAsRestriction Element="StateIDs" Fixed="1">
 <SelectedValues>2</SelectedValues>
 <SelectedValues>10</SelectedValues>

--- a/var/stats/ITSMStats-201-ITSMTicketFirstLevelSolutionRate.xml
+++ b/var/stats/ITSMStats-201-ITSMTicketFirstLevelSolutionRate.xml
@@ -23,7 +23,7 @@ Restrictions:
 <StatType>dynamic</StatType>
 <SumCol>1</SumCol>
 <SumRow>1</SumRow>
-<Title>First level solution rate for all tickets ever created per Ticket-Type and Queue.</Title>
+<Title>First level solution rate for all tickets ever created per Ticket-Type and Queue</Title>
 <UseAsRestriction Element="StateIDs" Fixed="1">
 <SelectedValues>2</SelectedValues>
 <SelectedValues>10</SelectedValues>

--- a/var/stats/ITSMStats-202-ITSMTicketFirstLevelSolutionRate.xml
+++ b/var/stats/ITSMStats-202-ITSMTicketFirstLevelSolutionRate.xml
@@ -23,7 +23,7 @@ Restrictions:
 <StatType>dynamic</StatType>
 <SumCol>1</SumCol>
 <SumRow>1</SumRow>
-<Title>First level solution rate for all tickets ever created per Ticket-Type and Service.</Title>
+<Title>First level solution rate for all tickets ever created per Ticket-Type and Service</Title>
 <UseAsRestriction Element="StateIDs" Fixed="1">
 <SelectedValues>2</SelectedValues>
 <SelectedValues>10</SelectedValues>

--- a/var/stats/ITSMStats-203-ITSMTicketFirstLevelSolutionRate.xml
+++ b/var/stats/ITSMStats-203-ITSMTicketFirstLevelSolutionRate.xml
@@ -24,7 +24,7 @@ Restrictions:
 <StatType>dynamic</StatType>
 <SumCol>1</SumCol>
 <SumRow>1</SumRow>
-<Title>Monthly overview of first level solution rate per Ticket-Type in the last month.</Title>
+<Title>Monthly overview of first level solution rate per Ticket-Type in the last month</Title>
 <UseAsRestriction Element="StateIDs" Fixed="1">
 <SelectedValues>2</SelectedValues>
 <SelectedValues>10</SelectedValues>

--- a/var/stats/ITSMStats-204-ITSMTicketFirstLevelSolutionRate.xml
+++ b/var/stats/ITSMStats-204-ITSMTicketFirstLevelSolutionRate.xml
@@ -24,7 +24,7 @@ Restrictions:
 <StatType>dynamic</StatType>
 <SumCol>1</SumCol>
 <SumRow>1</SumRow>
-<Title>Monthly overview of first level solution rate per Priority in the last month.</Title>
+<Title>Monthly overview of first level solution rate per Priority in the last month</Title>
 <UseAsRestriction Element="StateIDs" Fixed="1">
 <SelectedValues>2</SelectedValues>
 <SelectedValues>10</SelectedValues>

--- a/var/stats/ITSMStats-205-ITSMTicketFirstLevelSolutionRate.xml
+++ b/var/stats/ITSMStats-205-ITSMTicketFirstLevelSolutionRate.xml
@@ -24,7 +24,7 @@ Restrictions:
 <StatType>dynamic</StatType>
 <SumCol>1</SumCol>
 <SumRow>1</SumRow>
-<Title>Monthly overview of first level solution rate per Queue in the last month.</Title>
+<Title>Monthly overview of first level solution rate per Queue in the last month</Title>
 <UseAsRestriction Element="StateIDs" Fixed="1">
 <SelectedValues>2</SelectedValues>
 <SelectedValues>10</SelectedValues>

--- a/var/stats/ITSMStats-206-ITSMTicketFirstLevelSolutionRate.xml
+++ b/var/stats/ITSMStats-206-ITSMTicketFirstLevelSolutionRate.xml
@@ -24,7 +24,7 @@ Restrictions:
 <StatType>dynamic</StatType>
 <SumCol>1</SumCol>
 <SumRow>1</SumRow>
-<Title>Monthly overview of first level solution rate per Service in the last month.</Title>
+<Title>Monthly overview of first level solution rate per Service in the last month</Title>
 <UseAsRestriction Element="StateIDs" Fixed="1">
 <SelectedValues>2</SelectedValues>
 <SelectedValues>10</SelectedValues>

--- a/var/stats/ITSMStats-207-ITSMTicketFirstLevelSolutionRate.xml
+++ b/var/stats/ITSMStats-207-ITSMTicketFirstLevelSolutionRate.xml
@@ -24,7 +24,7 @@ Restrictions:
 <StatType>dynamic</StatType>
 <SumCol>1</SumCol>
 <SumRow>1</SumRow>
-<Title>First level solution rate for all tickets created in a specific time period per Ticket-Type and Priority.</Title>
+<Title>First level solution rate for all tickets created in a specific time period per Ticket-Type and Priority</Title>
 <UseAsRestriction Element="StateIDs" Fixed="1">
 <SelectedValues>2</SelectedValues>
 <SelectedValues>10</SelectedValues>

--- a/var/stats/ITSMStats-208-ITSMTicketFirstLevelSolutionRate.xml
+++ b/var/stats/ITSMStats-208-ITSMTicketFirstLevelSolutionRate.xml
@@ -24,7 +24,7 @@ Restrictions:
 <StatType>dynamic</StatType>
 <SumCol>1</SumCol>
 <SumRow>1</SumRow>
-<Title>First level solution rate for all tickets created in a specific time period per Ticket-Type and Queue.</Title>
+<Title>First level solution rate for all tickets created in a specific time period per Ticket-Type and Queue</Title>
 <UseAsRestriction Element="StateIDs" Fixed="1">
 <SelectedValues>2</SelectedValues>
 <SelectedValues>10</SelectedValues>

--- a/var/stats/ITSMStats-209-ITSMTicketFirstLevelSolutionRate.xml
+++ b/var/stats/ITSMStats-209-ITSMTicketFirstLevelSolutionRate.xml
@@ -24,7 +24,7 @@ Restrictions:
 <StatType>dynamic</StatType>
 <SumCol>1</SumCol>
 <SumRow>1</SumRow>
-<Title>First level solution rate for all tickets created in a specific time period per Ticket-Type and Service.</Title>
+<Title>First level solution rate for all tickets created in a specific time period per Ticket-Type and Service</Title>
 <UseAsRestriction Element="StateIDs" Fixed="1">
 <SelectedValues>2</SelectedValues>
 <SelectedValues>10</SelectedValues>

--- a/var/stats/ITSMStats-300-ITSMTicketSolutionTimeAverage.xml
+++ b/var/stats/ITSMStats-300-ITSMTicketSolutionTimeAverage.xml
@@ -22,7 +22,7 @@ Restrictions:
 <StatType>dynamic</StatType>
 <SumCol>0</SumCol>
 <SumRow>0</SumRow>
-<Title>Average solution time for all tickets ever created per Ticket-Type and Priority.</Title>
+<Title>Average solution time for all tickets ever created per Ticket-Type and Priority</Title>
 <UseAsRestriction Element="StateIDs" Fixed="1">
 <SelectedValues>2</SelectedValues>
 <SelectedValues>10</SelectedValues>

--- a/var/stats/ITSMStats-301-ITSMTicketSolutionTimeAverage.xml
+++ b/var/stats/ITSMStats-301-ITSMTicketSolutionTimeAverage.xml
@@ -22,7 +22,7 @@ Restrictions:
 <StatType>dynamic</StatType>
 <SumCol>0</SumCol>
 <SumRow>0</SumRow>
-<Title>Average solution time for all tickets ever created per Ticket-Type and Queue.</Title>
+<Title>Average solution time for all tickets ever created per Ticket-Type and Queue</Title>
 <UseAsRestriction Element="StateIDs" Fixed="1">
 <SelectedValues>2</SelectedValues>
 <SelectedValues>10</SelectedValues>

--- a/var/stats/ITSMStats-302-ITSMTicketSolutionTimeAverage.xml
+++ b/var/stats/ITSMStats-302-ITSMTicketSolutionTimeAverage.xml
@@ -22,7 +22,7 @@ Restrictions:
 <StatType>dynamic</StatType>
 <SumCol>0</SumCol>
 <SumRow>0</SumRow>
-<Title>Average solution time for all tickets ever created per Ticket-Type and Service.</Title>
+<Title>Average solution time for all tickets ever created per Ticket-Type and Service</Title>
 <UseAsRestriction Element="StateIDs" Fixed="1">
 <SelectedValues>2</SelectedValues>
 <SelectedValues>10</SelectedValues>

--- a/var/stats/ITSMStats-303-ITSMTicketSolutionTimeAverage.xml
+++ b/var/stats/ITSMStats-303-ITSMTicketSolutionTimeAverage.xml
@@ -23,7 +23,7 @@ Restrictions:
 <StatType>dynamic</StatType>
 <SumCol>0</SumCol>
 <SumRow>0</SumRow>
-<Title>Monthly overview of the average solution time per Ticket-Type in the last month.</Title>
+<Title>Monthly overview of the average solution time per Ticket-Type in the last month</Title>
 <UseAsRestriction Element="StateIDs" Fixed="1">
 <SelectedValues>2</SelectedValues>
 <SelectedValues>10</SelectedValues>

--- a/var/stats/ITSMStats-304-ITSMTicketSolutionTimeAverage.xml
+++ b/var/stats/ITSMStats-304-ITSMTicketSolutionTimeAverage.xml
@@ -23,7 +23,7 @@ Restrictions:
 <StatType>dynamic</StatType>
 <SumCol>0</SumCol>
 <SumRow>0</SumRow>
-<Title>Monthly overview of the average solution time per Priority in the last month.</Title>
+<Title>Monthly overview of the average solution time per Priority in the last month</Title>
 <UseAsRestriction Element="StateIDs" Fixed="1">
 <SelectedValues>2</SelectedValues>
 <SelectedValues>10</SelectedValues>

--- a/var/stats/ITSMStats-305-ITSMTicketSolutionTimeAverage.xml
+++ b/var/stats/ITSMStats-305-ITSMTicketSolutionTimeAverage.xml
@@ -23,7 +23,7 @@ Restrictions:
 <StatType>dynamic</StatType>
 <SumCol>0</SumCol>
 <SumRow>0</SumRow>
-<Title>Monthly overview of the average solution time per Queue in the last month.</Title>
+<Title>Monthly overview of the average solution time per Queue in the last month</Title>
 <UseAsRestriction Element="StateIDs" Fixed="1">
 <SelectedValues>2</SelectedValues>
 <SelectedValues>10</SelectedValues>

--- a/var/stats/ITSMStats-306-ITSMTicketSolutionTimeAverage.xml
+++ b/var/stats/ITSMStats-306-ITSMTicketSolutionTimeAverage.xml
@@ -23,7 +23,7 @@ Restrictions:
 <StatType>dynamic</StatType>
 <SumCol>0</SumCol>
 <SumRow>0</SumRow>
-<Title>Monthly overview of the average solution time per Service in the last month.</Title>
+<Title>Monthly overview of the average solution time per Service in the last month</Title>
 <UseAsRestriction Element="StateIDs" Fixed="1">
 <SelectedValues>2</SelectedValues>
 <SelectedValues>10</SelectedValues>

--- a/var/stats/ITSMStats-307-ITSMTicketSolutionTimeAverage.xml
+++ b/var/stats/ITSMStats-307-ITSMTicketSolutionTimeAverage.xml
@@ -23,7 +23,7 @@ Restrictions:
 <StatType>dynamic</StatType>
 <SumCol>0</SumCol>
 <SumRow>0</SumRow>
-<Title>Average solution time of tickets created in the last month per Ticket-Type and Priority.</Title>
+<Title>Average solution time of tickets created in the last month per Ticket-Type and Priority</Title>
 <UseAsRestriction Element="StateIDs" Fixed="1">
 <SelectedValues>2</SelectedValues>
 <SelectedValues>10</SelectedValues>

--- a/var/stats/ITSMStats-308-ITSMTicketSolutionTimeAverage.xml
+++ b/var/stats/ITSMStats-308-ITSMTicketSolutionTimeAverage.xml
@@ -23,7 +23,7 @@ Restrictions:
 <StatType>dynamic</StatType>
 <SumCol>0</SumCol>
 <SumRow>0</SumRow>
-<Title>Average solution time of tickets created in the last month per Ticket-Type and Queue.</Title>
+<Title>Average solution time of tickets created in the last month per Ticket-Type and Queue</Title>
 <UseAsRestriction Element="StateIDs" Fixed="1">
 <SelectedValues>2</SelectedValues>
 <SelectedValues>10</SelectedValues>

--- a/var/stats/ITSMStats-309-ITSMTicketSolutionTimeAverage.xml
+++ b/var/stats/ITSMStats-309-ITSMTicketSolutionTimeAverage.xml
@@ -23,7 +23,7 @@ Restrictions:
 <StatType>dynamic</StatType>
 <SumCol>0</SumCol>
 <SumRow>0</SumRow>
-<Title>Average solution time of tickets created in the last month per Ticket-Type and Service.</Title>
+<Title>Average solution time of tickets created in the last month per Ticket-Type and Service</Title>
 <UseAsRestriction Element="StateIDs" Fixed="1">
 <SelectedValues>2</SelectedValues>
 <SelectedValues>10</SelectedValues>


### PR DESCRIPTION
Hi @mgruner 
The stats names contains no trailing dots in OTRS, but these are sentences. See other stats in OTRS Framework: https://github.com/OTRS/otrs/tree/master/var/stats
Both rel-6_0 and master are affected.